### PR TITLE
Remove response.data.status check

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3565,11 +3565,6 @@ function run() {
                 core.setFailed(`The GitHub API for comparing the base and head commits for this ${github_1.context.eventName} event returned ${response.status}, expected 200. ` +
                     "Please submit an issue on this action's GitHub repo.");
             }
-            // Ensure that the head commit is ahead of the base commit.
-            if (response.data.status !== 'ahead') {
-                core.setFailed(`The head commit for this ${github_1.context.eventName} event is not ahead of the base commit. ` +
-                    "Please submit an issue on this action's GitHub repo.");
-            }
             // Get the changed files from the response payload.
             const files = response.data.files;
             const all = [], added = [], modified = [], removed = [], renamed = [], addedModified = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,14 +74,6 @@ async function run(): Promise<void> {
       )
     }
 
-    // Ensure that the head commit is ahead of the base commit.
-    if (response.data.status !== 'ahead') {
-      core.setFailed(
-        `The head commit for this ${context.eventName} event is not ahead of the base commit. ` +
-          "Please submit an issue on this action's GitHub repo."
-      )
-    }
-
     // Get the changed files from the response payload.
     const files = response.data.files
     const all = [] as string[],


### PR DESCRIPTION
It's perfectly valid for a head to be "behind" a base when comparing commits for pull request events. For example, PRing a feature branch of `main` while other commits have landed on `main` after the feature branch was started but before the PR was created, or a PR to merge a "development" branch onto a slower moving "release" branch that has some hotfixes on it.