### PR TITLE
Fix jq example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Consider using one of the other formats if that's the case.
   with:
     format: 'json'
 - run: |
-    readarray -t removed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.removed }}')"
-    for removed_file in ${removed_files[@]}; do
+    readarray -t removed_files < <(jq -r '.[]' <<<'${{ steps.files.outputs.removed }}')
+    for removed_file in "${removed_files[@]}"; do
       echo "Do something with this ${removed_file}."
     done
 ```


### PR DESCRIPTION
Using `<<<` appends a new line to the output which in turn makes readline add an empty string to the array if the output of jq is empty.

I got hit with this bug after using the example code and adding some filters. Here are more details: https://stackoverflow.com/a/64093036